### PR TITLE
setup PATH and TMP environment variables for finding gcc on windows …

### DIFF
--- a/src/openalea/sconsx/config.py
+++ b/src/openalea/sconsx/config.py
@@ -383,6 +383,7 @@ def ALEASolution(options, tools=[], dir=[]):
                 env_compiler_options['TARGET_ARCH'] = compilerenv['TARGET_ARCH']
         elif compilerenv['compiler'] == 'mingw':
             env_compiler_options['tools'] = ['mingw']
+            env_compiler_options['ENV'] = {'PATH': [find_executable_path_from_env('gcc.exe', strip_bin=False)],'TMP': os.environ['TMP']}
     
     conf = Config(tools, dir)
     conf.UpdateOptions(options)


### PR DESCRIPTION
…(also allow to find the conda installed compilers)
close #43 